### PR TITLE
Updating README for correct kdbush usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Inspired by [sphere-knn](https://github.com/darkskyapp/sphere-knn), but uses a d
 var kdbush = require('kdbush');
 var geokdbush = require('geokdbush');
 
-var index = kdbush(points, (p) => p.lon, (p) => p.lat);
+var index = new kdbush(points, (p) => p.lon, (p) => p.lat);
 
 var nearest = geokdbush.around(index, -119.7051, 34.4363, 1000);
 ```


### PR DESCRIPTION
This had me stunned for a bit, if you follow the original README you'll get an error such as the following,

```
> kdbush(points, (p) => p.lon, (p) => p.lat);
TypeError: Cannot set property 'nodeSize' of undefined
    at KDBush (${project_path}/node_modules/kdbush/kdbush.js:169:19)
```

This is because kdbush is actually representing a class that has be constructed, as shown in both that projects [README](https://github.com/mourner/kdbush/blob/master/README.md) and [example benchmark](https://github.com/mourner/kdbush/blob/master/bench.js#L15).